### PR TITLE
feat: add extra-files parameter

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,9 @@ inputs:
     description: Release Please release type
     required: false
     default: node
+  extra-files:
+    description: Extra files in which release please should bump the version
+    required: false
 outputs:
   release_created:
     description: A release was successfully created
@@ -77,6 +80,7 @@ runs:
         prerelease: ${{ inputs.prerelease }}
         default-branch: ${{ github.ref_name }}
         release-as: ${{ steps.get-next-version.outputs.version }}
+        extra-files: ${{ inputs.extra-files }}
 
     - name: 🔑 Set Git User
       shell: bash


### PR DESCRIPTION
Adds a new `extra-files` optional parameter that is passed through to the release please action. This allows the bumping of versions in arbitrary files using the generic updater (they need to be annotated with a special comment).

[use case](https://github.com/agrc/electrofishing/pull/284/files)